### PR TITLE
ci: add step to upload APK as artifact for M1 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --parallel --build-cache
+
+        # Upload the APK as an artifact for M1 (only on M1 branch)
+      - name: Upload APK for M1
+        if: github.ref == 'refs/heads/M1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: M1-APK
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
# Add APK upload for M1 branch in CI workflow

This PR updates our GitHub Actions CI workflow to automatically upload the Android APK as an artifact **only for a branch called M1**.

## Changes
- Added a new step `Upload APK for M1` at the end of the CI job.
- The step uses `actions/upload-artifact@v4` to upload the generated debug APK (`app/build/outputs/apk/debug/app-debug.apk`).
- Added a condition `if: github.ref == 'refs/heads/M1'` so the APK is uploaded **only when the workflow runs on the M1 branch**.
- This allows coaches to download a stable APK for M1 testing without affecting builds on other branches.

## How to use
1. Push or open a PR to the `M1` branch.
2. Check the GitHub Actions run; in the **Artifacts** section, there should be a `M1-APK` available for download.
3. Download the APK and install it on a device.

This PR is related to task #116.
