### PR TITLE
fix: move button add to prevent the timeAxis from shifting

### DIFF
--- a/app/src/main/java/com/android/sample/ui/calendar/CalendarContainer.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/CalendarContainer.kt
@@ -2,8 +2,17 @@ package com.android.sample.ui.calendar
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import com.android.sample.ui.calendar.data.LocalDateRange
 import com.android.sample.ui.calendar.mockData.MockEvent
 import com.android.sample.ui.calendar.style.CalendarDefaults
@@ -37,6 +46,12 @@ fun CalendarContainer(
             // Later : give dateRange (like Monday-Friday) and events list from ViewModel
             // Later : give onEventClick and onEventLongPress
             )
+        IconButton(
+            onClick = {},
+            modifier =
+                Modifier.align(Alignment.TopStart).padding(top = 5.dp, start = 8.dp).size(35.dp)) {
+              Icon(imageVector = Icons.Default.Add, contentDescription = "Add", tint = Color.Gray)
+            }
 
         // Later : manage visual swiping effects here
       }

--- a/app/src/main/java/com/android/sample/ui/calendar/components/TimeAxisColumn.kt
+++ b/app/src/main/java/com/android/sample/ui/calendar/components/TimeAxisColumn.kt
@@ -9,14 +9,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
@@ -50,13 +45,11 @@ internal fun TimeAxisColumn(
     style: GridContentStyle = defaultGridContentStyle(),
     scrollState: ScrollState = rememberScrollState()
 ) {
-  Column(
+  Box(
       modifier = Modifier.width(leftOffsetDp).height(gridHeightDp),
       // Total height of the scrollable grid
   ) {
-    IconButton(onClick = {}, modifier = Modifier.size(32.dp)) {
-      Icon(imageVector = Icons.Default.Add, contentDescription = "Add", tint = Color.Gray)
-    }
+
     // Regular time labels (hours)
     Column(
         modifier =


### PR DESCRIPTION
This PR fixes a layout issue introduced in the previous merge #117, where the temporary “+” button caused a slight misalignment in the TimeAxis column of the calendar view.

The button has now been moved out of the TimeAxis layout and placed within the CalendarContainer, allowing it to float independently without affecting the grid alignment or the time labels.

This change ensures the TimeAxis and calendar grid remain visually aligned, while preserving the button’s visibility for E2E testing purposes.

Fixes #121 