### PR TITLE
fix: modify CI actions to restore the google-service file from base64

### DIFF
--- a/.github/workflows/buildapk.yml
+++ b/.github/workflows/buildapk.yml
@@ -39,7 +39,13 @@ jobs:
 
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew
-
+        
+      - name: Restore google-services.json
+        run: |
+          mkdir -p app
+          echo "${{ secrets.GOOGLE_SERVICES }}" | base64 --decode > app/google-services.json
+          test -s app/google-services.json && echo "google-services.json restored"
+          
       - name: Build APK
         run: |
           VARIANT=${{ github.event.inputs['build-type'] || 'Release' }}


### PR DESCRIPTION
Added support for restoring google-services.json from a GitHub secret during CI.
The workflow now decodes the file before the build, allowing Firebase integration without versioning the file.