### PR TITLE
fix : Refactor event creation in CalendarEventsTest

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/CalendarEventsTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/CalendarEventsTest.kt
@@ -49,7 +49,6 @@ class CalendarEventsTest {
     compose
         .onNodeWithTag("${CalendarScreenTestTags.EVENT_BLOCK}_Test Event")
         .assertExists()
-        .performScrollTo()
         .assertIsDisplayed()
   }
 
@@ -60,40 +59,35 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Monday Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Monday guy",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),
             MockEvent(
                 title = "Tuesday Event",
                 date = LocalDate.now().with(DayOfWeek.TUESDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Tuesday guy",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),
             MockEvent(
                 title = "Wednesday Event",
                 date = LocalDate.now().with(DayOfWeek.WEDNESDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Wednesday guy",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),
             MockEvent(
                 title = "Thursday Event",
                 date = LocalDate.now().with(DayOfWeek.THURSDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Thursday guy",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),
             MockEvent(
                 title = "Friday Event",
                 date = LocalDate.now().with(DayOfWeek.FRIDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Friday guy",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),
@@ -119,16 +113,14 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Out-of-range (early) Event",
                 date = LocalDate.of(2000, 1, 1),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Méline",
                 backgroundColor = 0xFF81C784.toInt(),
             ),
             MockEvent(
                 title = "Out-of-range (late) Event",
                 date = LocalDate.of(2100, 1, 1),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Nathan",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),
@@ -152,8 +144,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Last Sunday Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY.minus(1)),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Weifeng",
                 backgroundColor = 0xFFFFB74D.toInt(),
             ),
@@ -161,8 +152,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Next Saturday Event",
                 date = LocalDate.now().with(DayOfWeek.FRIDAY.plus(1)),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(1)),
                 assigneeName = "Haobin",
                 backgroundColor = 0xFFBA68C8.toInt(),
             ),
@@ -186,8 +176,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "First semi-overlapping Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(2)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(2)),
                 assigneeName = "Timaël",
                 backgroundColor = 0xFF81C784.toInt(),
             ),
@@ -195,8 +184,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Second semi-overlapping Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(10, 0), duration = Duration.ofHours(2)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(10, 0), duration = Duration.ofHours(2)),
                 assigneeName = "Noa",
                 backgroundColor = 0xFFE57373.toInt(),
             ),
@@ -220,8 +208,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "First full-overlapping Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(2)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(2)),
                 assigneeName = "Timaël",
                 backgroundColor = 0xFF81C784.toInt(),
             ),
@@ -229,8 +216,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Second full-overlapping Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(2)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(9, 0), duration = Duration.ofHours(2)),
                 assigneeName = "Noa",
                 backgroundColor = 0xFFE57373.toInt(),
             ),
@@ -255,8 +241,7 @@ class CalendarEventsTest {
             MockEvent(
                 title = "Morning Event",
                 date = LocalDate.now().with(DayOfWeek.MONDAY),
-                timeSpan =
-                    TimeSpan.of(start = LocalTime.of(6, 0), duration = Duration.ofHours(4)),
+                timeSpan = TimeSpan.of(start = LocalTime.of(6, 0), duration = Duration.ofHours(4)),
                 assigneeName = "Méline",
                 backgroundColor = 0xFF64B5F6.toInt(),
             ),


### PR DESCRIPTION
Fixed the logic error in calendarGridContent_showsEventBlocks_whenEventsProvided. Previously it generated and event on the 14th of October and checked whether it was displayed; but since the calendar view dynamically changes to the current week, the 14th of October was not anymore in the span of the calendar. Fixing it by adding an event to a date of the current week.

https://github.com/swent-agendapp/agendapp/issues/268