### PR TITLE
Add language selection screen under settings

### DIFF
--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -31,6 +31,7 @@ import com.android.sample.ui.profile.ProfileScreen
 import com.android.sample.ui.replacement.ReplacementPendingListScreen
 import com.android.sample.ui.replacement.ReplacementScreen
 import com.android.sample.ui.screens.HomeScreen
+import com.android.sample.ui.settings.LanguageSelectionScreen
 import com.android.sample.ui.settings.SettingsScreen
 import com.android.sample.ui.theme.SampleAppTheme
 import com.github.se.bootcamp.model.authentication.AuthRepositoryFirebase
@@ -111,7 +112,11 @@ fun Agendapp(modifier: Modifier = Modifier) {
           composable(Screen.Settings.route) {
             SettingsScreen(
                 onNavigateBack = { navigationActions.navigateBack() },
-                onNavigateToProfile = { navigationActions.navigateTo(Screen.Profile) })
+                onNavigateToProfile = { navigationActions.navigateTo(Screen.Profile) },
+                onNavigateToLanguage = { navigationActions.navigateTo(Screen.LanguageSelection) })
+          }
+          composable(Screen.LanguageSelection.route) {
+            LanguageSelectionScreen(onNavigateBack = { navigationActions.navigateBack() })
           }
           composable(Screen.Profile.route) {
             ProfileScreen(

--- a/app/src/main/java/com/android/sample/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/Screen.kt
@@ -13,6 +13,8 @@ sealed class Screen(val route: String) {
 
   data object Settings : Screen("settings")
 
+  data object LanguageSelection : Screen("settings/language")
+
   data object Profile : Screen("profile")
 
   data object AdminContact : Screen("admin_contact")

--- a/app/src/main/java/com/android/sample/ui/settings/LanguageSelectionScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/settings/LanguageSelectionScreen.kt
@@ -1,0 +1,81 @@
+package com.android.sample.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.android.sample.R
+
+object LanguageSelectionScreenTestTags {
+  const val ROOT = "language_selection_screen"
+  const val APPLY_BUTTON = "language_apply_button"
+  const val OPTION_PREFIX = "language_option_"
+}
+
+/** Screen that allows the user to pick the preferred application language. */
+@Composable
+fun LanguageSelectionScreen(onNavigateBack: () -> Unit = {}) {
+  var selectedLanguage by rememberSaveable { mutableStateOf("en") }
+  val languageOptions = listOf(
+      "en" to stringResource(R.string.language_option_english),
+      "fr" to stringResource(R.string.language_option_french),
+      "es" to stringResource(R.string.language_option_spanish),
+      "de" to stringResource(R.string.language_option_german))
+
+  Surface(modifier = Modifier.fillMaxSize().semantics { testTag = LanguageSelectionScreenTestTags.ROOT }) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)) {
+          Text(
+              text = stringResource(R.string.language_screen_title),
+              style = MaterialTheme.typography.headlineSmall,
+              fontWeight = FontWeight.Bold)
+          Text(
+              text = stringResource(R.string.language_screen_description),
+              style = MaterialTheme.typography.bodyMedium,
+              color = MaterialTheme.colorScheme.onSurfaceVariant)
+          Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            languageOptions.forEach { (code, label) ->
+              Row(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .testTag("${LanguageSelectionScreenTestTags.OPTION_PREFIX}$code"),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(selected = selectedLanguage == code, onClick = { selectedLanguage = code })
+                    Spacer(modifier = Modifier.size(12.dp))
+                    Text(text = label, style = MaterialTheme.typography.bodyLarge)
+                  }
+            }
+          }
+          Spacer(modifier = Modifier.weight(1f))
+          Button(
+              modifier =
+                  Modifier.fillMaxWidth().testTag(LanguageSelectionScreenTestTags.APPLY_BUTTON),
+              onClick = onNavigateBack) {
+                Text(text = stringResource(R.string.language_apply_button_label))
+              }
+        }
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/settings/SettingsScreen.kt
@@ -17,10 +17,14 @@ object SettingsScreenTestTags {
   const val ROOT = "settings_screen"
   const val BACK_BUTTON = "back_button"
   const val PROFILE_BUTTON = "profile_button"
+  const val LANGUAGE_BUTTON = "language_button"
 }
 /** Settings screen with navigation to profile. */
 @Composable
-fun SettingsScreen(onNavigateBack: () -> Unit = {}, onNavigateToProfile: () -> Unit = {}) {
+fun SettingsScreen(
+    onNavigateBack: () -> Unit = {},
+    onNavigateToProfile: () -> Unit = {},
+    onNavigateToLanguage: () -> Unit = {}) {
   Surface(modifier = Modifier.fillMaxSize().semantics { testTag = SettingsScreenTestTags.ROOT }) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -32,6 +36,12 @@ fun SettingsScreen(onNavigateBack: () -> Unit = {}, onNavigateToProfile: () -> U
               modifier = Modifier.testTag(SettingsScreenTestTags.PROFILE_BUTTON),
               onClick = onNavigateToProfile) {
                 Text(stringResource(R.string.settings_profile_button))
+              }
+          Spacer(modifier = Modifier.height(16.dp))
+          Button(
+              modifier = Modifier.testTag(SettingsScreenTestTags.LANGUAGE_BUTTON),
+              onClick = onNavigateToLanguage) {
+                Text(stringResource(R.string.settings_language_button))
               }
           Spacer(modifier = Modifier.height(16.dp))
           Button(modifier = Modifier.testTag(BACK_BUTTON), onClick = onNavigateBack) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,16 @@
     <!-- Settings Screen -->
     <string name="settings_screen_title">Settings Screen</string>
     <string name="settings_profile_button">Profile</string>
+    <string name="settings_language_button">Language</string>
+
+    <!-- Language Selection Screen -->
+    <string name="language_screen_title">Choose your language</string>
+    <string name="language_screen_description">Select the language you would like to use in the application.</string>
+    <string name="language_apply_button_label">Apply language</string>
+    <string name="language_option_english">English</string>
+    <string name="language_option_french">Français</string>
+    <string name="language_option_spanish">Español</string>
+    <string name="language_option_german">Deutsch</string>
 
     <!-- Profile Screen -->
     <string name="profile_email_error">Please enter a valid email address</string>


### PR DESCRIPTION
## Summary
- add a dedicated language selection screen with radio options and apply button
- hook the new screen into the settings navigation flow and expose a language button
- define localized strings for the new language options

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e430b42bc832fa30b3449dec7f3d4)