### PR TITLE
Add method to retrieve organization members

### DIFF
--- a/app/src/androidTest/java/com/android/sample/model/organizationRepositoryTest/OrganizationFirebaseRepositoryTest.kt
+++ b/app/src/androidTest/java/com/android/sample/model/organizationRepositoryTest/OrganizationFirebaseRepositoryTest.kt
@@ -169,4 +169,21 @@ class OrganizationFirebaseRepositoryTest : FirebaseEmulatedTest() {
     val adminBRemaining = repository.getAllOrganizations(adminB)
     assertEquals(setOf("orgC"), adminBRemaining.map { it.id }.toSet())
   }
+
+  @Test
+  fun getMembersOfOrganization_asMember_shouldReturnMembers() = runBlocking {
+    repository.insertOrganization(orgA, adminA)
+    val members = repository.getMembersOfOrganization(orgA.id, memberA)
+    val memberIds = members.map { it.id }.toSet()
+    assertEquals(setOf("memberA", "adminA"), memberIds)
+  }
+
+  @Test
+  fun getMembersOfOrganization_asOutsider_shouldThrow() = runBlocking {
+    repository.insertOrganization(orgA, adminA)
+    try {
+      repository.getMembersOfOrganization(orgA.id, outsider)
+      fail("Expected IllegalArgumentException for outsider")
+    } catch (_: IllegalArgumentException) {}
+  }
 }

--- a/app/src/main/java/com/android/sample/model/organizations/OrganizationRepository.kt
+++ b/app/src/main/java/com/android/sample/model/organizations/OrganizationRepository.kt
@@ -70,11 +70,30 @@ interface OrganizationRepository {
   /**
    * Retrieves an organization by its unique identifier.
    *
-   * Implementations should ensure the user has access rights to this organization.
+   * Implementations should ensure the user has access rights to this organization (user is member
+   * or admin).
    *
    * @param organizationId The unique identifier of the organization.
    * @param user The current user performing the action.
    * @return The organization if found and accessible, or null if not found or unauthorized.
    */
   suspend fun getOrganizationById(organizationId: String, user: User): Organization?
+
+  /**
+   * Retrieves all members of a specific organization.
+   *
+   * Implementations should ensure the user has access rights to this organization (user is member
+   * or admin).
+   *
+   * @param organizationId The unique identifier of the organization.
+   * @param user The current user performing the action.
+   * @return A list of users who are members of the organization.
+   */
+  suspend fun getMembersOfOrganization(organizationId: String, user: User): List<User> {
+    val organization =
+        getOrganizationById(organizationId, user)
+            ?: throw IllegalArgumentException(
+                "Organization with id $organizationId does not exist.")
+    return organization.members
+  }
 }

--- a/app/src/test/java/com/android/sample/model/organizationRepositoryTest/OrganizationRepositoryLocalTest.kt
+++ b/app/src/test/java/com/android/sample/model/organizationRepositoryTest/OrganizationRepositoryLocalTest.kt
@@ -182,4 +182,22 @@ class OrganizationRepositoryLocalTest {
     val adminBRemaining = repository.getAllOrganizations(adminB)
     assertEquals(setOf("orgC"), adminBRemaining.map { it.id }.toSet())
   }
+
+  @Test
+  fun getMembersOfOrganization_asMember_shouldReturnMembers() = runBlocking {
+    repository.insertOrganization(orgC, adminA)
+
+    val members = repository.getMembersOfOrganization(orgC.id, memberA)
+    val memberIds = members.map { it.id }.toSet()
+
+    assertEquals(setOf("memberA", "memberB"), memberIds)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun getMembersOfOrganization_asOutsider_shouldThrow() {
+    runBlocking {
+      repository.insertOrganization(orgC, adminA)
+      repository.getMembersOfOrganization(orgC.id, outsider)
+    }
+  }
 }


### PR DESCRIPTION
## What has been changed
This PR introduces a a new method for organization repos to retrieve the members of the organization and unit testing.

The main updates include:

---

### Core Data Models
- **OrganizationRepository**: 
  - `getMembersOfOrganization` : Return the members of an organization given the id of this organization.

All `OrganizationRepository` implementations already include this new method by default, as it relies on the existing `getOrganizationById` method and is defined directly in the `OrganizationRepository` interface.

---

### Unit Tests Added
- **Organization Repository Tests**:
  - **OrganizationRepositoryLocalTest**:
    - **Retrievals**: Verify a member of an organization can get all the members of his organization and outsiders cannot.
  - **OrganizationFirebaseRepositoryTest**:
    - Mirrors the local repository tests but against the Firebase emulator.

---

### Note

SonarCloud reports the new `getMembersOfOrganization` method as uncovered because it’s implemented as a default method directly in the interface. While this approach is cleaner from a code design perspective, it results in a false lack of coverage in SonarCloud.

---

### Related tasks
- Close #237 (Task)
- Related to #32 (User story)
