### PR TITLE
feat: add confirmed future replacement screen

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/replacement/ReplacementUpcomingListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/replacement/ReplacementUpcomingListScreenTest.kt
@@ -1,0 +1,83 @@
+package com.android.sample.ui.replacement
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.sample.model.replacement.Replacement
+import com.android.sample.model.replacement.ReplacementStatus
+import com.android.sample.model.replacement.mockData.getMockReplacements
+import com.android.sample.ui.theme.SampleAppTheme
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+// Assisted by AI
+class ReplacementUpcomingListScreenTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private fun upcomingMocks(): List<Replacement> {
+        return getMockReplacements().take(3).map {
+            it.copy(status = ReplacementStatus.Accepted)
+        }
+    }
+
+    @Test
+    fun screen_displaysScreenAndList() {
+        composeTestRule.setContent {
+            SampleAppTheme {
+                ReplacementUpcomingListScreen(replacements = upcomingMocks())
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(ReplacementUpcomingTestTags.SCREEN, useUnmergedTree = true)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithTag(ReplacementUpcomingTestTags.LIST, useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun screen_displaysOneCardPerReplacement() {
+        val replacements = upcomingMocks()
+
+        composeTestRule.setContent {
+            SampleAppTheme {
+                ReplacementUpcomingListScreen(replacements = replacements)
+            }
+        }
+
+        replacements.forEach { replacement ->
+            composeTestRule
+                .onNodeWithTag(
+                    ReplacementUpcomingTestTags.itemTag(replacement.id),
+                    useUnmergedTree = true)
+                .assertIsDisplayed()
+        }
+    }
+@Test
+    fun screen_displaysEventTitleAndSubstitute() {
+        val replacements = upcomingMocks()
+        val first = replacements.first()
+
+        composeTestRule.setContent {
+            SampleAppTheme {
+                ReplacementUpcomingListScreen(replacements = replacements)
+            }
+        }
+
+        composeTestRule.onNodeWithText(first.event.title).assertIsDisplayed()
+
+        composeTestRule
+            .onAllNodesWithText(first.substituteUserId, substring = true)
+            .onFirst()
+            .assertIsDisplayed()
+    }
+
+}

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -42,6 +42,7 @@ import com.android.sample.ui.profile.AdminContactScreen
 import com.android.sample.ui.profile.ProfileScreen
 import com.android.sample.ui.replacement.ReplacementOverviewScreen
 import com.android.sample.ui.replacement.ReplacementPendingListScreen
+import com.android.sample.ui.replacement.ReplacementUpcomingListScreen
 import com.android.sample.ui.replacement.organize.ReplacementOrganizeScreen
 import com.android.sample.ui.settings.SettingsScreen
 import com.android.sample.ui.theme.SampleAppTheme
@@ -213,6 +214,9 @@ fun Agendapp(
                           },
                           onWaitingConfirmationClick = {
                             navigationActions.navigateTo(Screen.ReplacementPending)
+                          },
+                          onConfirmedClick = {
+                              navigationActions.navigateTo(Screen.ReplacementUpcoming)
                           })
                     }
                     composable(Screen.ReplacementOrganize.route) {
@@ -226,6 +230,11 @@ fun Agendapp(
                     // Pending Replacement Screen
                     composable(Screen.ReplacementPending.route) {
                       ReplacementPendingListScreen(
+                          onNavigateBack = { navigationActions.navigateBack() })
+                    }
+                  // accepted replacement screen
+                    composable(Screen.ReplacementUpcoming.route) {
+                      ReplacementUpcomingListScreen(
                           onNavigateBack = { navigationActions.navigateBack() })
                     }
                   }

--- a/app/src/main/java/com/android/sample/model/replacement/mockData/MockReplacements.kt
+++ b/app/src/main/java/com/android/sample/model/replacement/mockData/MockReplacements.kt
@@ -32,8 +32,8 @@ fun getMockReplacements(): List<Replacement> {
       createEvent(
           title = "Reunion C",
           description = "Afternoon meeting",
-          startDate = Instant.parse("2025-11-03T14:00:00Z"),
-          endDate = Instant.parse("2025-11-03T16:00:00Z"),
+          startDate = Instant.parse("2025-12-03T14:00:00Z"),
+          endDate = Instant.parse("2025-12-03T16:00:00Z"),
           cloudStorageStatuses = setOf(CloudStorageStatus.FIRESTORE),
           color = EventColor.Orange)
 

--- a/app/src/main/java/com/android/sample/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/Screen.kt
@@ -37,4 +37,6 @@ sealed class Screen(val route: String, val name: String) {
   data object EditEvent : Screen("edit_event/{eventId}", name = "Edit Event") {
     fun createRoute(eventId: String) = "edit_event/$eventId"
   }
+
+  data object ReplacementUpcoming : Screen("replacement/upcoming", name = "Replacement Upcoming")
 }

--- a/app/src/main/java/com/android/sample/ui/replacement/ReplacementUpcomingListScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/replacement/ReplacementUpcomingListScreen.kt
@@ -1,0 +1,156 @@
+package com.android.sample.ui.replacement
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.android.sample.R
+import com.android.sample.model.replacement.Replacement
+import com.android.sample.model.replacement.ReplacementStatus
+import com.android.sample.model.replacement.mockData.getMockReplacements
+import com.android.sample.ui.calendar.utils.DateTimeUtils.DATE_FORMAT_PATTERN
+import com.android.sample.ui.theme.CornerRadiusLarge
+import com.android.sample.ui.theme.PaddingMedium
+import com.android.sample.ui.theme.SpacingMedium
+import com.android.sample.ui.theme.SpacingSmall
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+object ReplacementUpcomingTestTags {
+  const val SCREEN = "replacement_upcoming_screen"
+  const val LIST = "replacement_upcoming_list"
+  private const val ITEM_PREFIX = "replacement_upcoming_item_"
+
+  fun itemTag(id: String): String = ITEM_PREFIX + id
+}
+
+/**
+ * Screen showing future confirmed replacements
+ *
+ * A replacement is considered "upcoming" if:
+ * - it's status is [ReplacementStatus.Accepted]
+ * - it's event start date is in the future
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReplacementUpcomingListScreen(
+    replacements: List<Replacement> = getMockReplacements().filterUpcomingAccepted(),
+    onNavigateBack: () -> Unit = {},
+) {
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = {
+              Text(
+                  text =
+                      androidx.compose.ui.res.stringResource(R.string.replacement_upcoming_title))
+            },
+            navigationIcon = {
+              IconButton(onClick = onNavigateBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription =
+                        androidx.compose.ui.res.stringResource(R.string.common_back))
+              }
+            })
+      }) { paddingValues ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(PaddingMedium)
+                    .testTag(ReplacementUpcomingTestTags.SCREEN)) {
+              LazyColumn(
+                  modifier = Modifier.fillMaxSize().testTag(ReplacementUpcomingTestTags.LIST),
+                  verticalArrangement = Arrangement.spacedBy(SpacingMedium)) {
+                    items(replacements, key = { it.id }) { replacement ->
+                      ReplacementUpcomingCard(replacement = replacement)
+                    }
+                  }
+            }
+      }
+}
+
+/** Card for a future confirmed replacement. */
+@Composable
+private fun ReplacementUpcomingCard(replacement: Replacement) {
+  val dateFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
+  val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+  val dateText = replacement.event.startLocalDate.format(dateFormatter)
+  val timeText =
+      "${replacement.event.startLocalTime.format(timeFormatter)} - " +
+          replacement.event.endLocalTime.format(timeFormatter)
+
+  Card(
+      modifier =
+          Modifier.fillMaxWidth().testTag(ReplacementUpcomingTestTags.itemTag(replacement.id)),
+      shape = RoundedCornerShape(CornerRadiusLarge),
+      elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
+        Column(modifier = Modifier.fillMaxWidth().padding(PaddingMedium)) {
+          Text(
+              text = replacement.event.title,
+              style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis)
+          Spacer(modifier = Modifier.height(SpacingSmall))
+
+          Text(text = "$dateText • $timeText", style = MaterialTheme.typography.bodyMedium)
+          Spacer(modifier = Modifier.height(SpacingSmall))
+
+          Text(
+              text =
+                  androidx.compose.ui.res.stringResource(
+                      id = R.string.replacement_substituted_label, replacement.absentUserId),
+              style = MaterialTheme.typography.bodySmall)
+
+          Text(
+              text =
+                  androidx.compose.ui.res.stringResource(
+                      id = R.string.replacement_substitute_label, replacement.substituteUserId),
+              style = MaterialTheme.typography.bodySmall)
+        }
+      }
+}
+
+/**
+ * Helper to filter a list of [Replacement] and keep only:
+ * - Accepted replacements
+ * - Events strictly in the future (based on system clock)
+ */
+private fun List<Replacement>.filterUpcomingAccepted(
+    now: Instant = Instant.now(),
+): List<Replacement> =
+    this.filter { replacement ->
+      replacement.status == ReplacementStatus.Accepted && replacement.event.startDate.isAfter(now)
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun ReplacementUpcomingListScreenPreview() {
+  ReplacementUpcomingListScreen(replacements = getMockReplacements())
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -172,6 +172,7 @@
     <string name="replacement_create_select_event">Ereignis auswählen</string>
     <string name="replacement_create_choose_date_range">Datumsbereich auswählen</string>
     <string name="event_overview_title">Ereignisübersicht</string>
+    <string name="replacement_upcoming_title">Bevorstehende Vertretungen</string>
 
     <!-- Organizations -->
     <string name="organization_list_title">Ihre organisationen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -172,6 +172,7 @@
     <string name="replacement_create_select_event">Sélectionner un événement</string>
     <string name="replacement_create_choose_date_range">Choisir une plage de dates</string>
     <string name="event_overview_title">Aperçu de l\'événement</string>
+    <string name="replacement_upcoming_title">Remplacements à venir</string>
 
     <!-- Organizations -->
     <string name="organization_list_title">Vos organisations</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="organize_replacement">Organize a replacement</string>
     <string name="process_replacement">Replacement to process</string>
     <string name="waiting_confirmation_replacement">Waiting replacement confirmation</string>
-    <string name="confirmed_replacements">Confirmed replacements</string>
+    <string name="confirmed_replacements">Upcoming replacements</string>
 
     <!-- Common -->
     <string name="common_back">Back</string>
@@ -88,6 +88,7 @@
     <string name="select_events">Select events</string>
     <string name="select_date_range">Select date range</string>
     <string name="search_icon_content_description">Search icon</string>
+    <string name="replacement_upcoming_title">Upcoming replacements</string>
 
     <!-- Settings Screen -->
     <string name="settings_screen_title">Settings</string>


### PR DESCRIPTION
This PR introduces a new screen displaying all upcoming replacements assigned to the user.
The goal is to give  administrators a clear overview of confirmed replacements that are scheduled for the future.

### What’s included
- New UI Screen
-  Navigation
-  Added UI Tests
verifying:
The screen loads correctly
Future confirmed replacements are displayed
Past or unconfirmed replacements do not show
Empty state message appears when no upcoming replacements exist

### How to Test
**Manually :**

Launch the app.
Go to Replacement tab.
Tap Confirmed replacements

<img width="300" height="630" alt="image" src="https://github.com/user-attachments/assets/c360778a-bb88-441a-a849-d6c88a300fe0" />

Linked to #248