### PR TITLE
fix : fixed e2e test issue

### DIFF
--- a/app/src/androidTest/java/com/android/sample/e2eTests/AddEventE2ETest.kt
+++ b/app/src/androidTest/java/com/android/sample/e2eTests/AddEventE2ETest.kt
@@ -1,6 +1,5 @@
 package com.android.sample.e2eTests
 
-import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -204,7 +203,6 @@ class AddEventE2ETest : FirebaseEmulatedTest() {
       maxDownScrolls: Int = 30,
       maxUpScrolls: Int = 60
   ) {
-    Log.e("toto", "tot")
     if (isTagDisplayed(eventTag)) return
     val calendarNode = onNodeWithTag(calendarTag)
 


### PR DESCRIPTION
Changed from assertExist() to assertIsDisplayed() in scrollTo() in order to really scroll to the event when testing.

#379 