### PR TITLE
Fix color/category bug in main branch

### DIFF
--- a/app/objectbox-models/default.json
+++ b/app/objectbox-models/default.json
@@ -5,7 +5,7 @@
   "entities": [
     {
       "id": "1:8567047882002894516",
-      "lastPropertyId": "16:6131044006357806497",
+      "lastPropertyId": "17:7843856300579761234",
       "name": "EventEntity",
       "properties": [
         {
@@ -80,13 +80,13 @@
           "type": 9
         },
         {
-          "id": "15:1698775154728145695",
-          "name": "color",
-          "type": 5
-        },
-        {
           "id": "16:6131044006357806497",
           "name": "presence",
+          "type": 9
+        },
+        {
+          "id": "17:7843856300579761234",
+          "name": "category",
           "type": 9
         }
       ],
@@ -101,7 +101,9 @@
   "modelVersionParserMinimum": 5,
   "retiredEntityUids": [],
   "retiredIndexUids": [],
-  "retiredPropertyUids": [],
+  "retiredPropertyUids": [
+    1698775154728145695
+  ],
   "retiredRelationUids": [],
   "version": 1
 }

--- a/app/objectbox-models/default.json.bak
+++ b/app/objectbox-models/default.json.bak
@@ -5,7 +5,7 @@
   "entities": [
     {
       "id": "1:8567047882002894516",
-      "lastPropertyId": "15:1698775154728145695",
+      "lastPropertyId": "16:6131044006357806497",
       "name": "EventEntity",
       "properties": [
         {
@@ -83,6 +83,11 @@
           "id": "15:1698775154728145695",
           "name": "color",
           "type": 5
+        },
+        {
+          "id": "16:6131044006357806497",
+          "name": "presence",
+          "type": 9
         }
       ],
       "relations": []

--- a/app/src/main/java/com/android/sample/data/local/mappers/EventMapper.kt
+++ b/app/src/main/java/com/android/sample/data/local/mappers/EventMapper.kt
@@ -1,7 +1,5 @@
 package com.android.sample.data.local.mappers
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import com.android.sample.data.local.objects.EventEntity
 import com.android.sample.data.local.utils.decodeBooleanMap
 import com.android.sample.data.local.utils.decodeList
@@ -33,7 +31,7 @@ object EventMapper {
         version = version,
         hasBeenDeleted = hasBeenDeleted,
         recurrenceStatus = recurrenceStatus.name,
-        color = color.toArgb())
+        category = category)
   }
 
   /* Maps an EventEntity from local database storage to an Event domain model. */
@@ -58,6 +56,6 @@ object EventMapper {
         recurrenceStatus =
             runCatching { RecurrenceStatus.valueOf(recurrenceStatus) }
                 .getOrDefault(RecurrenceStatus.OneTime),
-        color = Color(color))
+        category = category)
   }
 }

--- a/app/src/main/java/com/android/sample/data/local/objects/EventEntity.kt
+++ b/app/src/main/java/com/android/sample/data/local/objects/EventEntity.kt
@@ -1,10 +1,10 @@
 package com.android.sample.data.local.objects
 
-import androidx.compose.ui.graphics.toArgb
+import com.android.sample.data.local.utils.EventCategoryConverter
 import com.android.sample.data.local.utils.InstantConverter
 import com.android.sample.data.local.utils.encodeBooleanMap
 import com.android.sample.model.calendar.RecurrenceStatus
-import com.android.sample.ui.theme.EventPalette
+import com.android.sample.model.category.EventCategory
 import io.objectbox.annotation.Convert
 import io.objectbox.annotation.Entity
 import io.objectbox.annotation.Id
@@ -27,7 +27,7 @@ import java.time.Instant
  * @param version The version timestamp of the event.
  * @param hasBeenDeleted Flag indicating if the event has been deleted.
  * @param recurrenceStatus The recurrence status of the event.
- * @param color The color associated with the event.
+ * @param category The category of the event.
  */
 @Entity
 data class EventEntity(
@@ -48,5 +48,6 @@ data class EventEntity(
     var version: Long = System.currentTimeMillis(),
     var hasBeenDeleted: Boolean = false,
     var recurrenceStatus: String = RecurrenceStatus.OneTime.name,
-    var color: Int = EventPalette.Blue.toArgb()
+    @Convert(converter = EventCategoryConverter::class, dbType = String::class)
+    var category: EventCategory = EventCategory.defaultCategory()
 )

--- a/app/src/main/java/com/android/sample/data/local/utils/EventCategoryConverter.kt
+++ b/app/src/main/java/com/android/sample/data/local/utils/EventCategoryConverter.kt
@@ -1,0 +1,48 @@
+package com.android.sample.data.local.utils
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.android.sample.model.category.EventCategory
+import com.android.sample.ui.theme.EventPalette
+import io.objectbox.converter.PropertyConverter
+import java.util.UUID
+import org.json.JSONObject
+
+class EventCategoryConverter : PropertyConverter<EventCategory, String> {
+  // Keys for serializing and deserializing EventCategory properties
+  private companion object {
+    const val KEY_ID = "id"
+    const val KEY_LABEL = "label"
+    const val KEY_COLOR = "color"
+    const val KEY_DEFAULT = "isDefault"
+  }
+
+  override fun convertToDatabaseValue(entityProperty: EventCategory?): String {
+    if (entityProperty == null) return ""
+    val json =
+        JSONObject().apply {
+          put(KEY_ID, entityProperty.id)
+          put(KEY_LABEL, entityProperty.label)
+          put(KEY_COLOR, entityProperty.color.toArgb())
+          put(KEY_DEFAULT, entityProperty.isDefault)
+        }
+    return json.toString()
+  }
+
+  override fun convertToEntityProperty(databaseValue: String?): EventCategory {
+    if (databaseValue.isNullOrBlank()) return EventCategory.defaultCategory()
+    val json = JSONObject(databaseValue)
+    val id = json.optString(KEY_ID, UUID.randomUUID().toString())
+    val label = json.optString(KEY_LABEL, "")
+    val colorLong = json.optLong(KEY_COLOR, EventPalette.NoCategory.value.toLong())
+    val color = Color(colorLong.toULong())
+    val isDefault = json.optBoolean(KEY_DEFAULT, false)
+
+    return EventCategory(
+        id = id,
+        label = label,
+        color = color,
+        isDefault = isDefault,
+    )
+  }
+}

--- a/app/src/test/java/com/android/sample/data/local/mappers/EventMapperTest.kt
+++ b/app/src/test/java/com/android/sample/data/local/mappers/EventMapperTest.kt
@@ -6,6 +6,7 @@ import com.android.sample.data.local.objects.EventEntity
 import com.android.sample.model.calendar.CloudStorageStatus
 import com.android.sample.model.calendar.Event
 import com.android.sample.model.calendar.RecurrenceStatus
+import com.android.sample.model.category.EventCategory
 import com.android.sample.ui.theme.EventPalette
 import java.time.Instant
 import org.junit.Assert.*
@@ -18,8 +19,14 @@ class EventMapperTest {
   private lateinit var emptyEvent: Event
   private lateinit var eventWithMalformedPresence: EventEntity
 
+  private lateinit var testCategory: EventCategory
+
   @Before
   fun setUp() {
+    testCategory =
+        EventCategory(
+            id = "test-category-id", label = "Work", color = EventPalette.Red, isDefault = false)
+
     baseEvent =
         Event(
             id = "event1",
@@ -36,7 +43,7 @@ class EventMapperTest {
             version = 12345L,
             hasBeenDeleted = false,
             recurrenceStatus = RecurrenceStatus.OneTime,
-            color = EventPalette.Blue)
+            category = testCategory)
 
     emptyEvent =
         baseEvent.copy(
@@ -62,7 +69,7 @@ class EventMapperTest {
     assertEquals(baseEvent.version, mappedBack.version)
     assertEquals(baseEvent.hasBeenDeleted, mappedBack.hasBeenDeleted)
     assertEquals(baseEvent.recurrenceStatus, mappedBack.recurrenceStatus)
-    assertEquals(baseEvent.color, mappedBack.color)
+    assertEquals(baseEvent.category, mappedBack.category)
 
     assertEquals(baseEvent.cloudStorageStatuses, mappedBack.cloudStorageStatuses)
     assertEquals(baseEvent.locallyStoredBy, mappedBack.locallyStoredBy)
@@ -91,9 +98,9 @@ class EventMapperTest {
   fun `Event color is correctly mapped via toArgb and back`() {
     val entity = baseEvent.toEntity()
     val mappedBack = entity.toEvent()
-    assertEquals(baseEvent.color, mappedBack.color)
+    assertEquals(baseEvent.category, mappedBack.category)
     // Check ARGB integer representation
-    assertEquals(baseEvent.color.value.toInt(), mappedBack.color.value.toInt())
+    assertEquals(baseEvent.category.color.value.toInt(), mappedBack.category.color.value.toInt())
   }
 
   @Test


### PR DESCRIPTION
## What has been changed

This PR fixes a bug in the main branch. This bug is due to a logic conflict between 2 branches that have been merged simultaneously. The first one introduced an new object `EventEntity` to store it locally (with mappers etc...) and the second changed the previous `color` field of an `Event` into a `eventCategory`.

So there was a conflit of logic on the `EventEntity` object because it was still using `color` while `Event` was using `category`. This passed under our radars because there was no merge conflicts between those 2 branches even if the logic of one had consequencies on the other.

So this PR fix this problem by introducing a new `EventCategoryConverter` (like the `InstantConverter`) and changing the `color` attribute into a `category` one in `EventEntity`.

---

- Close #384 (Task)  
- Related to no User Story (Bug fix)
