### PR TITLE
Add hasBeenDeleted in EventMapper

### DIFF
--- a/app/src/main/java/com/android/sample/model/firestoreMappers/EventMapper.kt
+++ b/app/src/main/java/com/android/sample/model/firestoreMappers/EventMapper.kt
@@ -40,6 +40,7 @@ object EventMapper : FirestoreMapper<Event> {
 
     val presence = parsePresence(document["presence"])
     val version = document.getLong("version") ?: 0L
+    val hasBeenDeleted = document.getBoolean("hasBeenDeleted") ?: false
     val category = parseCategory(document["eventCategory"])
 
     return Event(
@@ -55,6 +56,7 @@ object EventMapper : FirestoreMapper<Event> {
         version = version,
         presence = presence,
         recurrenceStatus = recurrenceStatus,
+        hasBeenDeleted = hasBeenDeleted,
         category = category)
   }
 
@@ -92,6 +94,7 @@ object EventMapper : FirestoreMapper<Event> {
     val presence = parsePresence(data["presence"])
 
     val version = (data["version"] as? Number)?.toLong() ?: 0L
+    val hasBeenDeleted = data["hasBeenDeleted"] as? Boolean ?: false
     val category = parseCategory(data["eventCategory"])
 
     return Event(
@@ -107,6 +110,7 @@ object EventMapper : FirestoreMapper<Event> {
         version = version,
         presence = presence,
         recurrenceStatus = recurrenceStatus,
+        hasBeenDeleted = hasBeenDeleted,
         category = category)
   }
 
@@ -124,6 +128,7 @@ object EventMapper : FirestoreMapper<Event> {
         "version" to model.version,
         "presence" to model.presence,
         "recurrenceStatus" to model.recurrenceStatus.name,
+        "hasBeenDeleted" to model.hasBeenDeleted,
         "eventCategory" to
             mapOf(
                 "id" to model.category.id,


### PR DESCRIPTION
## What has been changed

This PR fixes a bug in the Firestroe `EventMapper`. The field `hasBeenDeleted` of an `Event` has not been added.

This PR fix this problem by adding this missing field in the methods `fromDocument()`, `fromMap()` and `toMap()` of the object `EventMapper`.

---

- Close #388 (Task)  
- Related to no User Story (Bug fix)
