### PR TITLE
fix: CI by setting up the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
       # Install Firebase CLI
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@12.9.1
 
       - name: Firestore Check
         run: |


### PR DESCRIPTION
Add a static version to firebase Emulator, so it doesn't have the Java 21 version problem in the Futur.