### PR TITLE
Exclude deleted events from hour recap

### DIFF
--- a/app/src/main/java/com/android/sample/model/calendar/EventRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/sample/model/calendar/EventRepositoryFirebase.kt
@@ -121,8 +121,8 @@ open class EventRepositoryFirebase(private val db: FirebaseFirestore) : BaseEven
 
     return snapshot
         .mapNotNull { EventMapper.fromDocument(document = it) }
-        // keep only events whose start is on/before the queried end
-        .filter { it.startDate <= endDate }
+        // keep only events whose start is on/before the queried end and are not deleted
+        .filter { it.startDate <= endDate && !it.hasBeenDeleted }
   }
 
   override suspend fun ensureOrganizationExists(orgId: String) {


### PR DESCRIPTION
## Summary
- filter out deleted events when querying Firebase-backed events for hour recap calculations
- update the hour recap ViewModel test fake to ignore deleted events and add coverage for deleted entries

## Testing
- `./gradlew test` *(fails: SDK location not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7a96bdd0832f8ea99f7e59b3c225)