### PR TITLE
Include past shift users without recorded presence

### DIFF
--- a/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapViewModel.kt
@@ -117,10 +117,7 @@ class HourRecapViewModel(
     val pastHours = eventRepository.calculateWorkedHoursPastEvents(orgId, start, end).toMap()
     val futureHours = eventRepository.calculateWorkedHoursFutureEvents(orgId, start, end).toMap()
     val events = eventRepository.getEventsBetweenDates(orgId, start, end)
-    val eventParticipants =
-        events.flatMap { event ->
-          event.participants + event.assignedUsers + event.presence.keys
-        }
+    val eventParticipants = events.flatMap { event -> event.allEventUserIds() }
     val allEmployeeIds = (pastHours.keys + futureHours.keys + eventParticipants).distinct()
     val users = userRepository.getUsersByIds(allEmployeeIds)
     val userMap = users.associateBy { it.id }
@@ -132,7 +129,7 @@ class HourRecapViewModel(
       val planned = futureHours[userId] ?: 0.0
       val userEvents =
           events
-              .filter { event -> userId in event.participants || userId in event.assignedUsers }
+              .filter { event -> userId in event.allEventUserIds() }
               .map { event -> event.toHourRecapEntry(userId, now) }
               .sortedBy { it.startDate }
 
@@ -164,6 +161,10 @@ class HourRecapViewModel(
         tookReplacement = tookReplacement,
         categoryColor = category.color,
     )
+  }
+
+  private fun Event.allEventUserIds(): Set<String> {
+    return participants + assignedUsers + presence.keys
   }
 
   companion object {

--- a/app/src/test/java/com/android/sample/ui/hourRecap/HourRecapViewModelTest.kt
+++ b/app/src/test/java/com/android/sample/ui/hourRecap/HourRecapViewModelTest.kt
@@ -343,6 +343,32 @@ class HourRecapViewModelTest {
   }
 
   @Test
+  fun `calculateWorkedHours includes events tracked only in presence map`() = runTest {
+    val vm = makeVm()
+    val pastTime = Instant.now().minus(2, ChronoUnit.DAYS)
+    val presenceOnlyEvent =
+        createEvent(
+            organizationId = selectedOrganizationID,
+            startDate = pastTime,
+            endDate = pastTime.plus(2, ChronoUnit.HOURS),
+            participants = emptySet(),
+            assignedUsers = emptySet(),
+            presence = mapOf(user.id to false))
+
+    repo.result = emptyList()
+    repo.events = presenceOnlyEvent
+
+    vm.calculateWorkedHours(
+        Instant.now().minus(3, ChronoUnit.DAYS), Instant.now().minus(1, ChronoUnit.DAYS))
+    advanceUntilIdle()
+
+    val recaps = vm.uiState.value.userRecaps
+    assertEquals(1, recaps.size)
+    assertEquals(user.id, recaps.first().userId)
+    assertEquals(1, recaps.first().events.size)
+  }
+
+  @Test
   fun `event entry has null presence for future events`() = runTest {
     val vm = makeVm()
     val futureTime = Instant.now().plus(1, ChronoUnit.DAYS)


### PR DESCRIPTION
## Summary
- include event participants, assigned users, and presence entries when building hour recaps so workers without recorded presence still appear
- add a regression test to cover users who only have past shifts with no recorded presence

## Testing
- ./gradlew :app:testDebug --tests com.android.sample.ui.hourRecap.HourRecapViewModelTest *(fails: Android SDK location missing in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7c2b5e20832fbeb1866ed9b11804)