### PR TITLE
Add presence issue marker to hour recap cards

### DIFF
--- a/app/src/androidTest/java/com/android/sample/ui/hourRecap/HourRecapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/sample/ui/hourRecap/HourRecapScreenTest.kt
@@ -117,6 +117,58 @@ class HourRecapScreenTest : FirebaseEmulatedTest(), RequiresSelectedOrganization
   }
 
   @Test
+  fun recapItem_showsIssueMarkerWhenPresenceIsMissing() {
+    val vm = HourRecapViewModel()
+    val pastTime = java.time.Instant.now().minusSeconds(7200)
+
+    val missingPresenceEvent =
+        HourRecapEventEntry(
+            id = "event-missing",
+            title = "Morning Shift",
+            startDate = pastTime,
+            endDate = pastTime.plusSeconds(3600),
+            isPast = true,
+            wasPresent = null,
+            wasReplaced = false,
+            tookReplacement = false,
+            categoryColor = androidx.compose.ui.graphics.Color.Blue)
+
+    val confirmedPresenceEvent =
+        HourRecapEventEntry(
+            id = "event-confirmed",
+            title = "Afternoon Shift",
+            startDate = pastTime,
+            endDate = pastTime.plusSeconds(3600),
+            isPast = true,
+            wasPresent = true,
+            wasReplaced = false,
+            tookReplacement = false,
+            categoryColor = androidx.compose.ui.graphics.Color.Blue)
+
+    vm.setTestWorkedHours(
+        listOf(
+            HourRecapUserRecap(
+                userId = "alice",
+                displayName = "Alice",
+                completedHours = 2.0,
+                plannedHours = 0.0,
+                events = listOf(missingPresenceEvent)),
+            HourRecapUserRecap(
+                userId = "bob",
+                displayName = "Bob",
+                completedHours = 2.0,
+                plannedHours = 0.0,
+                events = listOf(confirmedPresenceEvent))))
+
+    compose.setContent { HourRecapScreen(hourRecapViewModel = vm) }
+
+    compose
+        .onNodeWithTag("${HourRecapTestTags.RECAP_ITEM_ISSUE_MARKER}_alice")
+        .assertExists()
+    compose.onNodeWithTag("${HourRecapTestTags.RECAP_ITEM_ISSUE_MARKER}_bob").assertDoesNotExist()
+  }
+
+  @Test
   fun emptyWorkedHours_showsEmptyList() {
     val vm = HourRecapViewModel()
     vm.setTestWorkedHours(emptyList())

--- a/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FileDownload
@@ -58,6 +59,7 @@ object HourRecapTestTags {
   const val GENERATE_BUTTON = "hour_recap_generate_button"
   const val RECAP_LIST = "hour_recap_list"
   const val RECAP_ITEM = "hour_recap_item"
+  const val RECAP_ITEM_ISSUE_MARKER = "hour_recap_item_issue_marker"
   const val RECAP_SHEET = "hour_recap_sheet"
   const val EXPORT_BUTTON = "hour_recap_export_button"
 }
@@ -404,8 +406,18 @@ private fun RecapItemCard(recap: HourRecapUserRecap, onClick: () -> Unit) {
         Column(modifier = Modifier.fillMaxWidth().padding(PaddingMedium)) {
           Row(
               modifier = Modifier.fillMaxWidth(),
-              horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically) {
+                if (recap.hasPresenceIssue) {
+                  Box(
+                      modifier =
+                          Modifier.size(12.dp)
+                              .clip(CircleShape)
+                              .background(MaterialTheme.colorScheme.error)
+                              .testTag(
+                                  "${HourRecapTestTags.RECAP_ITEM_ISSUE_MARKER}_${recap.userId}"))
+                  Spacer(Modifier.width(PaddingSmall))
+                }
+
                 Text(
                     text = recap.displayName,
                     style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapViewModel.kt
+++ b/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapViewModel.kt
@@ -42,6 +42,9 @@ data class HourRecapUserRecap(
 ) {
   val totalHours: Double
     get() = completedHours + plannedHours
+
+  val hasPresenceIssue: Boolean
+    get() = events.any { it.isPast && it.wasPresent != true }
 }
 
 data class HourRecapUiState(


### PR DESCRIPTION
## Summary
- flag hour recap users with past events that lack confirmed presence
- display a red issue indicator on employee recap cards
- cover the marker visibility with UI tests

## Testing
- Not run (Android SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e79170250832fbd320625580d99b5)