### PR TITLE
Adjust empty recap card padding

### DIFF
--- a/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapScreen.kt
+++ b/app/src/main/java/com/android/sample/ui/hourRecap/HourRecapScreen.kt
@@ -373,7 +373,7 @@ private fun EmptyRecapCard() {
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .padding(horizontal = SpacingLarge, vertical = SpacingMedium),
+                    .padding(horizontal = SpacingMedium, vertical = PaddingSmall),
             horizontalAlignment = Alignment.CenterHorizontally) {
               Icon(
                   imageVector = Icons.Default.Info,


### PR DESCRIPTION
## Summary
- reduce padding on the empty recap card to make the no-events message more compact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e801b4788832fa69f0467fc2f1d62)